### PR TITLE
Generalised the region regex to include any sequence of characters

### DIFF
--- a/jastro/ds9.py
+++ b/jastro/ds9.py
@@ -249,7 +249,7 @@ def read_region_file(region_filename, index_offset=1):
 
     comparisons = defaultdict(list)
     x, y, rsi, rso = [], [], [], []
-    region_regex = r'text={(?P<label>\w+)}'
+    region_regex = r'text={(?P<label>.*?)}'
     r = re.compile(region_regex)
     for i in f:
         match = r.match(i.comment)


### PR DESCRIPTION
Generalised the region regex to include any sequence of characters, allowing for spaces and special characters.

Previously (?P<label>\w+) captures one or more word characters (\w+) and assigns it to the named group label. Word characters include letters, digits, and underscores.

Now (?P<label>.*?): Captures any character (.) zero or more times (*) non-greedy (denoted by ?) and assigns it to the named group label. This allows it to capture any sequence of characters, including letters, digits, spaces, or special characters.

In effect this means that in the reg file you can provide a label with spaces:

annulus(2126,1138,9.0,14.0) # text={Tabby's Star}
